### PR TITLE
chore: format repo and add all non-npm lockfiles ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules/
 
 dist/
 .vercel
+
+yarn.lock
+pnpm-lock.yaml


### PR DESCRIPTION
- Run prettier across the repo
- update gitignore to include these two non-npm files
  - yarn.lock
  - pnpm-lock.yaml
Added to the branch: developer